### PR TITLE
Update terminalmessaging.css

### DIFF
--- a/octoprint_terminalmessaging/static/css/terminalmessaging.css
+++ b/octoprint_terminalmessaging/static/css/terminalmessaging.css
@@ -4,60 +4,18 @@
 
 #terminal-output span.received {
     position: relative;
-    font-family: sans-serif;
     font-size: 18px;
     line-height: 24px;
-    width: 400px;
-    background: #0000ff;
-    border-radius: 10px;
-    padding: 10px;
-    text-align: right;
-    color: #ffffff;
-    float: right;
-    margin-top: 10px;
+    text-align: left;
+    color: "blue";
     display: block;
-}
-
-#terminal-output span.received:before {
-    content: "";
-    width: 0px;
-    height: 0px;
-    position: absolute;
-    border-right: 24px solid #0000ff;
-    border-left: 12px solid transparent;
-    border-top: 12px solid #0000ff;
-    border-bottom: 20px solid transparent;
-    left: 368px;
-    bottom: -24px;
 }
 
 #terminal-output span.sent {
     position: relative;
-    font-family: sans-serif;
     font-size: 18px;
     line-height: 24px;
-    width: 400px;
-    background: #fff;
-    border-radius: 10px;
-    padding: 10px;
-    text-align: left;
-    color: #000;
-    float: left;
-    margin-top: 10px;
+    text-align: right;
+    color: "green";
     display: block;
 }
-
-#terminal-output span.sent:before {
-    content: "";
-    width: 0px;
-    height: 0px;
-    position: absolute;
-    border-left: 24px solid #fff;
-    border-right: 12px solid transparent;
-    border-top: 12px solid #fff;
-    border-bottom: 20px solid transparent;
-    left: 32px;
-    bottom: -24px;
-}
-
-

--- a/octoprint_terminalmessaging/static/css/terminalmessaging.css
+++ b/octoprint_terminalmessaging/static/css/terminalmessaging.css
@@ -7,7 +7,7 @@
     font-size: 18px;
     line-height: 24px;
     text-align: left;
-    color: "blue";
+    color: blue;
     display: block;
 }
 
@@ -16,6 +16,6 @@
     font-size: 18px;
     line-height: 24px;
     text-align: right;
-    color: "green";
+    color: green;
     display: block;
 }


### PR DESCRIPTION
I love that you were able to match the text messaging nature of it. But some messages from the controller are probably better to be left justified, and the forced width of 400px doesn't scale well, especially because I have the octoprint wide screen plugin enabled. I'm dialing it back a bit here, and I think it has a lot of the functionality, while missing all the flair, but it is useful for things like M122 from the TMC drivers or M503 with all the machine settings.

![screenshot-2020-07-23-1595534461](https://user-images.githubusercontent.com/1812882/88333761-fea89d00-cced-11ea-8354-d34b229de1d9.png)
